### PR TITLE
Unblock server on multiple HTTP requests

### DIFF
--- a/http.ts
+++ b/http.ts
@@ -17,7 +17,9 @@ function deferred(): Deferred {
     reject = rej;
   });
   return {
-    promise, resolve, reject,
+    promise,
+    resolve,
+    reject
   };
 }
 
@@ -50,7 +52,7 @@ export async function* serve(addr: string) {
   const listener = listen("tcp", addr);
   const env: ServeEnv = {
     reqQueue: [], // in case multiple promises are ready
-    serveDeferred: deferred(),
+    serveDeferred: deferred()
   };
 
   // Routine that keeps calling accept
@@ -58,12 +60,12 @@ export async function* serve(addr: string) {
     const handleConn = (conn: Conn) => {
       serveConn(env, conn); // don't block
       scheduleAccept(); // schedule next accept
-    }
+    };
     const scheduleAccept = () => {
       listener.accept().then(handleConn);
-    }
+    };
     scheduleAccept();
-  }
+  };
 
   acceptRoutine();
 

--- a/http_test.ts
+++ b/http_test.ts
@@ -5,8 +5,7 @@ const addr = "0.0.0.0:8000";
 const s = serve(addr);
 console.log(`listening on http://${addr}/`);
 
-const body = (new TextEncoder()).encode("Hello World\n");
-
+const body = new TextEncoder().encode("Hello World\n");
 
 async function main() {
   for await (const req of s) {


### PR DESCRIPTION
Closes #1 .
Resolve the immediate cause for blocking, by making new conn accept and readRequest of same level and async, ~~with `Promise.race`~~. Now `http_test.ts` should work properly.

~~(Currently there will be warnings of `Promise resolved after resolved`. The warning would go away after denoland/deno#1273)~~

~~Socket is closed for now once responding. Will need to change this behavior later.~~ Sockets are left open now until EOF.

I'm not quite sure if this fix is proper, and whether I should keep `serveConn` (since it is exported)
I will work more on http based on feedback for this change.